### PR TITLE
Remove webhook from this documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ You can find a full list of Trellis endpoints and schemas here: [Trellis API Doc
           // page -- the name of the page visited
           // params -- a dictionary object of additional pageview data
           page: handleTrellisAnalyticsPage,
-
-          // A URL that is called asynchronously by the Trellis API when it has completed
-          // pulling insurance data.
-          webhook: 'https://api.myserver.com/trellisUpdate'
         });
         document.getElementById('openTrellisButton').onclick = handler.open;
 })();


### PR DESCRIPTION
We don't actually use the webhook right now or really need it for anything, and having it in the docs as sample config means people are keeping it in and our scrapers are trying to request the sample URL.