### PR TITLE
Add trellisSessionId to onClose handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You can find a full list of Trellis endpoints and schemas here: [Trellis API Doc
 2. Configure a handler using `TrellisConnect.configure()` as shown in the example.
 3. Call your handler's `open()` method, and Trellis will present a modal dialog enabling the user to connect his or her insurance account.
 4. Have your `onSuccess` method pass the `accountId` to your application server, which can call Trellis API endpoints to retrieve information about that account. (Note: Your application server – not your web and mobile clients - should access the Trellis API because such access requires the use of your Trellis `API_SECRET_KEY`, which should never be publicly disseminated.)
+5. Your `onClose` callback will be passed the `trellisSessionId` in the metadata object. The `trellisSessionId` is required to associate the user's session for certain Trellis API requests.
 
 ```
 <script src="https://cdn.trellisconnect.com/sdk/v1.1/trellis-connect.js"></script>
@@ -33,10 +34,11 @@ You can find a full list of Trellis endpoints and schemas here: [Trellis API Doc
           // Called each time the user attempts to authenticate with their insurer and fails.
           onFailure: handleTrellisFailure,
 
-          // onClose()
+          // onClose(metadata)
           // Called when the user closes the modal dialog -- either when they have
           // successfully loaded their policies (potentially after an onSuccess() call) or by
           // clicking the "X" button in the top right of the modal.
+          // The metadata contains the trellisSessionId.
           onClose: handleTrellisClose,
 
           // track(event, params)
@@ -60,5 +62,7 @@ You can find a full list of Trellis endpoints and schemas here: [Trellis API Doc
 
 # CHANGELOG
 
+* 4/07/2020
+  * Update "onClose" handler to pass metadata that includes the trellisSesssionId.
 * 5/10/2019
   *  Renamed "key" to "client_id".  The tokens remain the same, this only rename of the field in this SDK.  There is an analogous rename in the [API Documentation](https://trellisconnect.com/docs) of the header from X-API-KEY to X-CLIENT-ID.  This was done to avoid confusion with the old names of API KEY and API SECRET KEY.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Trellis Logo](https://cdn.trellisconnect.com/sdk/v1.1/js-sdk/assets/images/header.png)
 
-Drop-in React-based modal for clients to easily access a user's current insurance information.
+Drop-in React-based widget for clients to easily access a user's current insurance information.
 
 # API Docs
 
@@ -10,9 +10,8 @@ You can find a full list of Trellis endpoints and schemas here: [Trellis API Doc
 
 1. Include our SDK on your page.
 2. Configure a handler using `TrellisConnect.configure()` as shown in the example.
-3. Call your handler's `open()` method, and Trellis will present a modal dialog enabling the user to connect his or her insurance account.
+3. Call your handler's `open()` method, and Trellis will present a widget enabling the user to connect his or her insurance account.
 4. Have your `onSuccess` method pass the `accountId` to your application server, which can call Trellis API endpoints to retrieve information about that account. (Note: Your application server – not your web and mobile clients - should access the Trellis API because such access requires the use of your Trellis `API_SECRET_KEY`, which should never be publicly disseminated.)
-5. Your `onClose` callback will be passed the `trellisSessionId` in the metadata object. The `trellisSessionId` is required to associate the user's session for certain Trellis API requests.
 
 ```
 <script src="https://cdn.trellisconnect.com/sdk/v1.1/trellis-connect.js"></script>
@@ -34,12 +33,15 @@ You can find a full list of Trellis endpoints and schemas here: [Trellis API Doc
           // Called each time the user attempts to authenticate with their insurer and fails.
           onFailure: handleTrellisFailure,
 
-          // onClose(metadata)
-          // Called when the user closes the modal dialog -- either when they have
+          // onClose(error, metadata)
+          // Called when the user closes the widget -- either when they have
           // successfully loaded their policies (potentially after an onSuccess() call) or by
-          // clicking the "X" button in the top right of the modal.
-          // The metadata contains the trellisSessionId.
-          onClose: handleTrellisClose,
+          // clicking the "X" button in the top right of the widget.
+          onClose: function(error, metadata) {
+            // metadata = {
+            //   trellisSessionId: 'f5d62241-6a9a-46cb-bae4-b4972d54fb58'
+            // }
+          },
 
           // track(event, params)
           // Similar in meaning to segment.com's analytics.track() call for events occuring


### PR DESCRIPTION
# Goal

- Adds `trellisSessionId` to the `onClose` handler.