### PR TITLE
Add "containerElement" API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Easily access a user's insurance information using Trellis Connect.
   (function () {
     var handler = TrellisConnect.configure({
       // Your Trellis Client-ID
-      client_id: '<API_CLIENT_ID>',
+      client_id: "<API_CLIENT_ID>",
 
       // onSuccess(connectionId, metadata)
       onSuccess: handleTrellisSuccess,
     });
-    document.getElementById('openTrellisButton').onclick = handler.open;
+    document.getElementById("openTrellisButton").onclick = handler.open;
   })();
 </script>
 ```
@@ -37,16 +37,16 @@ Easily access a user's insurance information using Trellis Connect.
   (function () {
     var handler = TrellisConnect.configure({
       // Your trellis API Client-Id
-      client_id: '<API_CLIENT_ID>',
+      client_id: "<API_CLIENT_ID>",
 
       // Optional Trellis identifier for your application.
-      application_id: '<APPLICATION_ID>',
+      application_id: "<APPLICATION_ID>",
 
       // The user object allows you to provide additional information about the user to be appended
       // reports. All fields are optional.
       user: {
         // An identifier you determine and submit for the user
-        client_user_id: '<CLIENT_USER_ID>',
+        client_user_id: "<CLIENT_USER_ID>",
       },
 
       // Set `closeConfirmation` to `false` to have users skip the confirmation dialog after clicking the close button.
@@ -110,8 +110,12 @@ Easily access a user's insurance information using Trellis Connect.
       // - ERROR
       //     - If an error happens during the flow.
       onEvent: handleEvent,
+      // OPTIONAL: Element which you want the Trellis Widget appended to. When not specified, the Trellis Widget will append to the body.
+      // We recommend you add the style `position: realtive` to the container element if you wish the iframe to be contained within the container element.
+      // The iframe overlay is absolutely positioned and will otherwise span outside of the container.
+      containerElement: document.querySelector(".custom-container"),
     });
-    document.getElementById('openTrellisButton').onclick = handler.open;
+    document.getElementById("openTrellisButton").onclick = handler.open;
   })();
 </script>
 ```
@@ -123,7 +127,7 @@ destroy() allows you to remove all DOM artifacts created by JS SDK. This functio
 ```html
 <script>
   // Create the Trellis handler
-  var handler = TrellisConnect.configure({ client_id: '<API_CLIENT_ID>' });
+  var handler = TrellisConnect.configure({ client_id: "<API_CLIENT_ID>" });
 
   // Destroy handler
   handler.destroy();

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Easily access a user's insurance information using Trellis Connect.
       //     - If an error happens during the flow.
       onEvent: handleEvent,
       // OPTIONAL: Element which you want the Trellis Widget appended to. When not specified, the Trellis Widget will append to the body.
-      // We recommend you add the style `position: relative` to the container element if you wish the iframe to be contained within the container element.
-      // The iframe overlay is absolutely positioned and will otherwise span outside of the container.
+      // We recommend you add the style `position: relative` to the container element if you wish the Trellis Widget overlay to be contained within the container element.
+      // The Trellis Widget overlay is absolutely positioned and will otherwise span outside of the container.
       containerElement: document.querySelector('.custom-container'),
     });
     document.getElementById('openTrellisButton').onclick = handler.open;

--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ Easily access a user's insurance information using Trellis Connect.
   (function () {
     var handler = TrellisConnect.configure({
       // Your trellis API Client-Id
-      client_id: "<API_CLIENT_ID>",
+      client_id: '<API_CLIENT_ID>',
 
       // Optional Trellis identifier for your application.
-      application_id: "<APPLICATION_ID>",
+      application_id: '<APPLICATION_ID>',
 
       // The user object allows you to provide additional information about the user to be appended
       // reports. All fields are optional.
       user: {
         // An identifier you determine and submit for the user
-        client_user_id: "<CLIENT_USER_ID>",
+        client_user_id: '<CLIENT_USER_ID>',
       },
 
       // Set `closeConfirmation` to `false` to have users skip the confirmation dialog after clicking the close button.
@@ -111,7 +111,7 @@ Easily access a user's insurance information using Trellis Connect.
       //     - If an error happens during the flow.
       onEvent: handleEvent,
       // OPTIONAL: Element which you want the Trellis Widget appended to. When not specified, the Trellis Widget will append to the body.
-      // We recommend you add the style `position: realtive` to the container element if you wish the iframe to be contained within the container element.
+      // We recommend you add the style `position: relative` to the container element if you wish the iframe to be contained within the container element.
       // The iframe overlay is absolutely positioned and will otherwise span outside of the container.
       containerElement: document.querySelector(".custom-container"),
     });
@@ -127,7 +127,7 @@ destroy() allows you to remove all DOM artifacts created by JS SDK. This functio
 ```html
 <script>
   // Create the Trellis handler
-  var handler = TrellisConnect.configure({ client_id: "<API_CLIENT_ID>" });
+  var handler = TrellisConnect.configure({ client_id: '<API_CLIENT_ID>' });
 
   // Destroy handler
   handler.destroy();

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Easily access a user's insurance information using Trellis Connect.
       // onSuccess(connectionId, metadata)
       onSuccess: handleTrellisSuccess,
     });
-    document.getElementById("openTrellisButton").onclick = handler.open;
+    document.getElementById('openTrellisButton').onclick = handler.open;
   })();
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Easily access a user's insurance information using Trellis Connect.
   (function () {
     var handler = TrellisConnect.configure({
       // Your Trellis Client-ID
-      client_id: "<API_CLIENT_ID>",
+      client_id: '<API_CLIENT_ID>',
 
       // onSuccess(connectionId, metadata)
       onSuccess: handleTrellisSuccess,
@@ -113,9 +113,9 @@ Easily access a user's insurance information using Trellis Connect.
       // OPTIONAL: Element which you want the Trellis Widget appended to. When not specified, the Trellis Widget will append to the body.
       // We recommend you add the style `position: relative` to the container element if you wish the iframe to be contained within the container element.
       // The iframe overlay is absolutely positioned and will otherwise span outside of the container.
-      containerElement: document.querySelector(".custom-container"),
+      containerElement: document.querySelector('.custom-container'),
     });
-    document.getElementById("openTrellisButton").onclick = handler.open;
+    document.getElementById('openTrellisButton').onclick = handler.open;
   })();
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ destroy() allows you to remove all DOM artifacts created by JS SDK. This functio
 
 # CHANGELOG
 
+- 11/2/2021
+  - Added `containerElement` api documentation
 - 5/7/2021
   - Added `onEvent` api documentation
 - 2/8/2021

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Easily access a user's insurance information using Trellis Connect.
       //     - If an error happens during the flow.
       onEvent: handleEvent,
       // OPTIONAL: Element which you want the Trellis Widget appended to. When not specified, the Trellis Widget will append to the body.
-      // We recommend you add the style `position: relative` to the container element if you wish the Trellis Widget overlay to be contained within the container element.
+      // We recommend you add the style `position: relative` to the container element if you want the Trellis Widget overlay to be contained within the container element.
       // The Trellis Widget overlay is absolutely positioned and will otherwise span outside of the container.
       containerElement: document.querySelector('.custom-container'),
     });


### PR DESCRIPTION
Added a new option to add a container element in which the Trellis Widget gets embedded. By default, the widget's iframe gets appended as a child of the `<body>`. 

Added some notes explaining how the new property functions and added an example of how `document.querySelector()` can be used to pass in the desired element.